### PR TITLE
fix: mumble username with spaces

### DIFF
--- a/src/app/games/mumble-join-button/mumble-join-button.component.spec.ts
+++ b/src/app/games/mumble-join-button/mumble-join-button.component.spec.ts
@@ -97,8 +97,22 @@ describe('MumbleJoinButtonComponent', () => {
           }
         },
       }});
+      component.gameId = 'FAKE_GAME_ID';
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('a'))).toBeFalsy();
+    });
+
+    it('should replace username spaces with underscores', () => {
+      store.setState({ ...initialState, profile: {
+        profile: {
+          id: 'FAKE_PLAYER_ID',
+          name: 'name with  spaces',
+        }
+      }});
+      component.gameId = 'FAKE_GAME_ID';
+      fixture.detectChanges();
+      const el = fixture.debugElement.query(By.css('a')).nativeElement as HTMLAnchorElement;
+      expect(el.href).toBe('mumble://name_with_spaces@melkor.tf/tf2pickup/5/RED');
     });
   });
 });

--- a/src/app/games/mumble-join-button/mumble-join-button.component.ts
+++ b/src/app/games/mumble-join-button/mumble-join-button.component.ts
@@ -33,7 +33,7 @@ export class MumbleJoinButtonComponent {
 
         const team = game.teams[mySlot.teamId];
         const url = urlParse(game.mumbleUrl);
-        url.set('username', theProfile.name);
+        url.set('username', theProfile.name.replace(/\s+/g, '_'));
         return `${url.toString()}/${team}`;
       }),
     );


### PR DESCRIPTION
Replace username white-spaces with underscores in mumble URLs.