### PR TITLE
fix: don't display pagination controls when game list is empty

### DIFF
--- a/src/app/games/game-list/game-list.component.html
+++ b/src/app/games/game-list/game-list.component.html
@@ -8,8 +8,13 @@
   </a>
 </div>
 
+<div *ngIf="(gameCount | async) === 0"
+  class="d-flex flex-row justify-content-center">
+  <span class="text-muted">no games</span>
+</div>
+
 <pagination-template #p="paginationApi" (pageChange)="getPage($event)">
-  <nav class="my-3">
+  <nav *ngIf="p.pages.length > 1" class="my-3">
     <ul class="pagination justify-content-center">
       <li class="page-item" [class.disabled]="p.isFirstPage()">
         <a class="page-link" aria-label="Previous" [routerLink]="" (click)="p.previous()">


### PR DESCRIPTION
* hide pagination controls when itemCount<=10
* show "no games" text when itemCount=0