### PR TITLE
fix: export global var

### DIFF
--- a/src/global-shim.ts
+++ b/src/global-shim.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error
+window.global = window;

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,6 +1,7 @@
 /***************************************************************************************************
  * BROWSER POLYFILLS
  */
+import './global-shim';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.


### PR DESCRIPTION
Export `window.global` as the `global` variable - fixes the reference error.