### PR TITLE
refactor: add EditPageWrapperComponent

### DIFF
--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -15,6 +15,7 @@ import { WhitelistEditComponent } from './whitelist-edit/whitelist-edit.componen
 import { DefaultPlayerSkillEditComponent } from './default-player-skill-edit/default-player-skill-edit.component';
 import { DocumentEditComponent } from './document-edit/document-edit.component';
 import { MarkdownModule } from 'ngx-markdown';
+import { EditPageWrapperComponent } from './edit-page-wrapper/edit-page-wrapper.component';
 
 @NgModule({
   imports: [
@@ -38,6 +39,7 @@ import { MarkdownModule } from 'ngx-markdown';
     WhitelistEditComponent,
     DefaultPlayerSkillEditComponent,
     DocumentEditComponent,
+    EditPageWrapperComponent,
   ],
 })
 export class AdminModule { }

--- a/src/app/admin/default-player-skill-edit/default-player-skill-edit.component.html
+++ b/src/app/admin/default-player-skill-edit/default-player-skill-edit.component.html
@@ -1,30 +1,7 @@
-<div class="container py-3">
-  <form
-    [formGroup]="form"
-    (submit)="save()">
-    <div class="d-flex align-items-center">
-      <button
-        type="button"
-        class="mdc-icon-button focus-none back-button"
-        tooltip="Go back"
-        placement="top"
-        container="body"
-        appNavigateBack>
-        <i-feather name="arrow-left" aria-hidden="true"></i-feather>
-      </button>
-
-      <div class="flex-grow-1 mdc-typography--headline5">
-        Default player skill
-      </div>
-
-      <button type="submit"
-        class="mdc-button mdc-button--raised mdc-button--secondary mx-2 submit-button"
-        [disabled]="(isSaving | async) === true || !form.valid || form.pristine">
-        <div class="mdc-button__ripple"></div>
-        <i-feather name="check" class="mdc-button__icon" aria-hidden="true"></i-feather>
-        <span class="mdc-button__label">save</span>
-      </button>
-    </div>
+<form [formGroup]="form" (submit)="save()">
+  <app-edit-page-wrapper
+    title="Default player skill"
+    [saveDisabled]="(isSaving | async) === true || !form.valid || form.pristine">
 
     <div class="surface surface--white py-4">
       <div class="mdc-typography--body1 mx-2">
@@ -50,5 +27,5 @@
         </div>
       </div>
     </div>
-  </form>
-</div>
+  </app-edit-page-wrapper>
+</form>

--- a/src/app/admin/default-player-skill-edit/default-player-skill-edit.component.spec.ts
+++ b/src/app/admin/default-player-skill-edit/default-player-skill-edit.component.spec.ts
@@ -9,6 +9,7 @@ import { FeatherComponent } from 'angular-feather';
 import { MockBuilder, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
+import { EditPageWrapperComponent } from '../edit-page-wrapper/edit-page-wrapper.component';
 import { DefaultPlayerSkillEditComponent } from './default-player-skill-edit.component';
 
 describe(DefaultPlayerSkillEditComponent.name, () => {
@@ -41,6 +42,7 @@ describe(DefaultPlayerSkillEditComponent.name, () => {
         },
       ]
     }))
+    .keep(EditPageWrapperComponent)
     .mock(FeatherComponent)
     .mock(GameClassIconComponent)
   );
@@ -68,7 +70,7 @@ describe(DefaultPlayerSkillEditComponent.name, () => {
 
   it('should render input for each game class', () => {
     expect(ngMocks.findAll('input[type=number]').length).toEqual(2);
-    const gameClassIcons = ngMocks.findInstances(GameClassIconComponent);
+    const gameClassIcons = ngMocks.findAll('app-game-class-icon').map(c => c.componentInstance);
     expect(gameClassIcons.length).toEqual(2);
     expect(gameClassIcons[0].gameClass).toEqual('scout');
     expect(gameClassIcons[1].gameClass).toEqual('soldier');

--- a/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.html
+++ b/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.html
@@ -1,0 +1,28 @@
+<div class="container py-3">
+  <div class="d-flex align-items-center">
+    <button goBackButton
+      type="button"
+      class="mdc-icon-button focus-none"
+      tooltip="Go back"
+      placement="top"
+      container="body"
+      appNavigateBack>
+      <i-feather name="arrow-left" aria-hidden="true"></i-feather>
+    </button>
+
+    <div class="flex-grow-1 mdc-typography--headline5" title>
+      {{ title }}
+    </div>
+
+    <button saveButton
+      type="submit"
+      class="mdc-button mdc-button--raised mdc-button--secondary mx-2 submit-button"
+      [disabled]="saveDisabled">
+      <div class="mdc-button__ripple"></div>
+      <i-feather name="check" class="mdc-button__icon" aria-hidden="true"></i-feather>
+      <span class="mdc-button__label">save</span>
+    </button>
+  </div>
+
+  <ng-content></ng-content>
+</div>

--- a/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.spec.ts
+++ b/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.spec.ts
@@ -1,0 +1,71 @@
+import { NavigateBackDirective } from '@app/shared/navigate-back.directive';
+import { FeatherComponent } from 'angular-feather';
+import { MockBuilder, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
+import { EditPageWrapperComponent } from './edit-page-wrapper.component';
+
+describe(EditPageWrapperComponent.name, () => {
+  let component: EditPageWrapperComponent;
+  let fixture: MockedComponentFixture<EditPageWrapperComponent>;
+
+  beforeEach(() => MockBuilder(EditPageWrapperComponent)
+    .mock(FeatherComponent)
+    .mock(NavigateBackDirective)
+  );
+
+  beforeEach(() => {
+    fixture = MockRender(EditPageWrapperComponent);
+    component = fixture.point.componentInstance;
+    component.title = 'just testing';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the title', () => {
+    const title = ngMocks.find('div.mdc-typography--headline5').nativeElement as HTMLElement;
+    expect(title.innerText).toEqual('just testing');
+  });
+
+  describe('go back button', () => {
+    it('should have the appNavigateBack directive', () => {
+      expect(ngMocks.find('button[goBackButton][appNavigateBack]')).toBeTruthy();
+    });
+  });
+
+  describe('save button', () => {
+    let saveButton: HTMLButtonElement;
+
+    beforeEach(() => {
+      saveButton = ngMocks.find('button[saveButton]').nativeElement;
+    });
+
+    it('should be rendered', () => {
+      expect(saveButton).toBeTruthy();
+      expect(saveButton.type).toEqual('submit');
+    });
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        component.saveDisabled = true;
+        fixture.detectChanges();
+      });
+
+      it('should be disabled', () => {
+        expect(saveButton.disabled).toBe(true);
+      });
+    });
+
+    describe('when enabled', () => {
+      beforeEach(() => {
+        component.saveDisabled = false;
+        fixture.detectChanges();
+      });
+
+      it('should be enabled', () => {
+        expect(saveButton.disabled).toBe(false);
+      });
+    });
+  });
+});

--- a/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.spec.ts
+++ b/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.spec.ts
@@ -1,19 +1,31 @@
+import { Component } from '@angular/core';
 import { NavigateBackDirective } from '@app/shared/navigate-back.directive';
 import { FeatherComponent } from 'angular-feather';
 import { MockBuilder, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { EditPageWrapperComponent } from './edit-page-wrapper.component';
 
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'test-wrapper',
+  template: '<app-edit-page-wrapper [title]="title" [saveDisabled]="saveDisabled"></app-edit-page-wrapper>',
+})
+class TestWrapperComponent {
+  title: string;
+  saveDisabled = false;
+}
+
 describe(EditPageWrapperComponent.name, () => {
-  let component: EditPageWrapperComponent;
+  let component: TestWrapperComponent;
   let fixture: MockedComponentFixture<EditPageWrapperComponent>;
 
-  beforeEach(() => MockBuilder(EditPageWrapperComponent)
+  beforeEach(() => MockBuilder(TestWrapperComponent)
+    .keep(EditPageWrapperComponent)
     .mock(FeatherComponent)
     .mock(NavigateBackDirective)
   );
 
   beforeEach(() => {
-    fixture = MockRender(EditPageWrapperComponent);
+    fixture = MockRender(TestWrapperComponent);
     component = fixture.point.componentInstance;
     component.title = 'just testing';
     fixture.detectChanges();

--- a/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.ts
+++ b/src/app/admin/edit-page-wrapper/edit-page-wrapper.component.ts
@@ -1,0 +1,17 @@
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-edit-page-wrapper',
+  templateUrl: './edit-page-wrapper.component.html',
+  styleUrls: ['./edit-page-wrapper.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditPageWrapperComponent {
+
+  @Input()
+  title: string;
+
+  @Input()
+  saveDisabled = true;
+
+}

--- a/src/app/admin/force-create-player-account/force-create-player-account.component.html
+++ b/src/app/admin/force-create-player-account/force-create-player-account.component.html
@@ -1,30 +1,7 @@
-<div class="container py-3">
-  <form
-    [formGroup]="form"
-    (submit)="save()">
-    <div class="d-flex align-items-center">
-      <button
-        type="button"
-        class="mdc-icon-button cancel-button focus-none"
-        tooltip="Cancel"
-        placement="top"
-        container="body"
-        appNavigateBack>
-        <i-feather name="x" aria-hidden="true"></i-feather>
-      </button>
-
-      <div class="flex-grow-1 mdc-typography--headline5">
-        Force create player account
-      </div>
-
-      <button type="submit"
-        class="mdc-button mdc-button--raised mdc-button--secondary mx-2 submit-button"
-        [disabled]="!form.valid || form.pristine">
-        <div class="mdc-button__ripple"></div>
-        <i-feather name="check" class="mdc-button__icon" aria-hidden="true"></i-feather>
-        <span class="mdc-button__label">save</span>
-      </button>
-    </div>
+<form [formGroup]="form" (submit)="save()">
+  <app-edit-page-wrapper
+    title="Force create player account"
+    [saveDisabled]="!form.valid || form.pristine">
 
     <div class="surface surface--white py-4">
       <label class="mdc-text-field mdc-text-field--outlined mx-2" #name>
@@ -55,5 +32,5 @@
           formControlName="steamId">
       </label>
     </div>
-  </form>
-</div>
+  </app-edit-page-wrapper>
+</form>

--- a/src/app/admin/force-create-player-account/force-create-player-account.component.spec.ts
+++ b/src/app/admin/force-create-player-account/force-create-player-account.component.spec.ts
@@ -6,6 +6,7 @@ import { PlayersService } from '@app/players/players.service';
 import { FeatherComponent } from 'angular-feather';
 import { MockBuilder, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { of } from 'rxjs';
+import { EditPageWrapperComponent } from '../edit-page-wrapper/edit-page-wrapper.component';
 import { ForceCreatePlayerAccountComponent } from './force-create-player-account.component';
 
 describe(ForceCreatePlayerAccountComponent.name, () => {
@@ -22,6 +23,7 @@ describe(ForceCreatePlayerAccountComponent.name, () => {
     .mock(PlayersService)
     .mock(Location)
     .mock(FeatherComponent)
+    .keep(EditPageWrapperComponent)
   );
 
   beforeEach(() => {

--- a/src/app/admin/map-pool-edit/map-pool-edit.component.html
+++ b/src/app/admin/map-pool-edit/map-pool-edit.component.html
@@ -1,30 +1,7 @@
-<div class="container py-3">
-  <form
-    [formGroup]="form"
-    (submit)="save()">
-    <div class="d-flex align-items-center">
-      <button
-        type="button"
-        class="mdc-icon-button cancel-button focus-none"
-        tooltip="Cancel"
-        placement="top"
-        container="body"
-        appNavigateBack>
-        <i-feather name="arrow-left" aria-hidden="true"></i-feather>
-      </button>
-
-      <div class="flex-grow-1 mdc-typography--headline5">
-        Map pool
-      </div>
-
-      <button type="submit"
-        class="mdc-button mdc-button--raised mdc-button--secondary mx-2 submit-button"
-        [disabled]="(store.enabled | async) === false || !form.valid || form.pristine">
-        <div class="mdc-button__ripple"></div>
-        <i-feather name="check" class="mdc-button__icon" aria-hidden="true"></i-feather>
-        <span class="mdc-button__label">save</span>
-      </button>
-    </div>
+<form [formGroup]="form" (submit)="save()">
+  <app-edit-page-wrapper
+    title="Map pool"
+    [saveDisabled]="(store.enabled | async) === false || !form.valid || form.pristine">
 
     <div class="surface surface--white py-4">
       <ng-container formArrayName="maps">
@@ -45,5 +22,5 @@
         <span class="mdc-button__label">Add map</span>
       </button>
     </div>
-  </form>
-</div>
+  </app-edit-page-wrapper>
+</form>

--- a/src/app/admin/map-pool-edit/map-pool-edit.component.spec.ts
+++ b/src/app/admin/map-pool-edit/map-pool-edit.component.spec.ts
@@ -6,6 +6,7 @@ import { AsFormGroupPipe } from '@app/shared/as-form-group.pipe';
 import { FeatherComponent } from 'angular-feather';
 import { MockBuilder, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { Subject } from 'rxjs';
+import { EditPageWrapperComponent } from '../edit-page-wrapper/edit-page-wrapper.component';
 import { MapEditComponent } from '../map-edit/map-edit.component';
 import { MapPoolEditComponent } from './map-pool-edit.component';
 
@@ -26,9 +27,10 @@ describe(MapPoolEditComponent.name, () => {
       fetchMaps: () => maps.asObservable(),
       setMaps: jasmine.createSpy('setMaps').and.returnValue(maps.asObservable()),
     })
+    .keep(EditPageWrapperComponent)
     .keep(MapEditComponent)
-    .mock(FeatherComponent)
     .keep(AsFormGroupPipe)
+    .mock(FeatherComponent)
   );
 
   beforeEach(() => {
@@ -50,13 +52,14 @@ describe(MapPoolEditComponent.name, () => {
   });
 
   describe('when maps are loaded', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       maps.next([{ name: 'cp_process_final' }, { name: 'cp_badlands' }]);
       fixture.detectChanges();
+      await fixture.whenStable();
     });
 
     it('should render map edits', () => {
-      const mapEdits = ngMocks.findInstances(MapEditComponent);
+      const mapEdits = ngMocks.findAll('app-map-edit');
       expect(mapEdits.length).toEqual(2);
     });
 
@@ -72,7 +75,7 @@ describe(MapPoolEditComponent.name, () => {
       });
 
       it('should add MapEditComponent', () => {
-        const mapEdits = ngMocks.findInstances(MapEditComponent);
+        const mapEdits = ngMocks.findAll('app-map-edit');
         expect(mapEdits.length).toEqual(3);
       });
 

--- a/src/app/admin/whitelist-edit/whitelist-edit.component.html
+++ b/src/app/admin/whitelist-edit/whitelist-edit.component.html
@@ -1,30 +1,8 @@
-<div class="container py-3">
-  <form
-    [formGroup]="form"
-    (submit)="save()">
-    <div class="d-flex align-items-center">
-      <button
-        type="button"
-        class="mdc-icon-button focus-none back-button"
-        tooltip="Go back"
-        placement="top"
-        container="body"
-        appNavigateBack>
-        <i-feather name="arrow-left" aria-hidden="true"></i-feather>
-      </button>
-
-      <div class="flex-grow-1 mdc-typography--headline5">
-        Whitelist
-      </div>
-
-      <button type="submit"
-        class="mdc-button mdc-button--raised mdc-button--secondary mx-2 submit-button"
-        [disabled]="(isSaving | async) === true || !form.valid || form.pristine">
-        <div class="mdc-button__ripple"></div>
-        <i-feather name="check" class="mdc-button__icon" aria-hidden="true"></i-feather>
-        <span class="mdc-button__label">save</span>
-      </button>
-    </div>
+<form [formGroup]="form" (submit)="save()">
+  <app-edit-page-wrapper
+    title="Whitelist"
+    [saveDisabled]="(isSaving | async) === true || !form.valid || form.pristine"
+    (save)="save()">
 
     <div class="surface surface--white py-4">
       <div class="mdc-typography--body1 mx-2">
@@ -52,5 +30,5 @@
         </a>
       </div>
     </div>
-  </form>
-</div>
+  </app-edit-page-wrapper>
+</form>

--- a/src/app/admin/whitelist-edit/whitelist-edit.component.spec.ts
+++ b/src/app/admin/whitelist-edit/whitelist-edit.component.spec.ts
@@ -6,6 +6,7 @@ import { FeatherComponent } from 'angular-feather';
 import { MockBuilder, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
+import { EditPageWrapperComponent } from '../edit-page-wrapper/edit-page-wrapper.component';
 import { WhitelistEditComponent } from './whitelist-edit.component';
 
 describe(WhitelistEditComponent.name, () => {
@@ -26,6 +27,7 @@ describe(WhitelistEditComponent.name, () => {
       setConfiguration: jasmine.createSpy('setConfiguration').and.returnValue(configuration.asObservable().pipe(take(1))),
     })
     .mock(FeatherComponent)
+    .keep(EditPageWrapperComponent)
   );
 
   beforeEach(() => {

--- a/src/app/admin/whitelist-edit/whitelist-edit.component.ts
+++ b/src/app/admin/whitelist-edit/whitelist-edit.component.ts
@@ -48,11 +48,15 @@ export class WhitelistEditComponent implements OnInit, AfterViewInit, OnDestroy 
   save() {
     this.isSaving.next(true);
     this.configurationService.fetchConfiguration().pipe(
-      switchMap(configuration => this.configurationService.setConfiguration({ ...configuration, whitelistId: this.form.get('whitelistId').value })),
+      switchMap(configuration => this.configurationService.setConfiguration({ ...configuration, whitelistId: this.whitelistId })),
       tap(configuration => this.form.reset(configuration)),
     ).subscribe(() => {
       this.isSaving.next(false);
     });
+  }
+
+  get whitelistId() {
+    return this.form.get('whitelistId').value;
   }
 
 }


### PR DESCRIPTION
Adds the EditPageWrapperComponent that wraps the common stuff across admin components, getting rid of code repetition (at least in the admin module).