### PR TITLE
fix: prevent re-creating the active game snackbar

### DIFF
--- a/src/app/games/games.selectors.spec.ts
+++ b/src/app/games/games.selectors.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable id-blacklist */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { gameById, activeGames, isPlayingGame, activeGame } from './games.selectors';
+import { gameById, activeGames, isPlayingGame, activeGame, activeGameId } from './games.selectors';
 import { Game } from './models/game';
 
 describe('gameById', () => {
@@ -58,6 +58,20 @@ describe('activeGame', () => {
 
     it('should return the active game', () => {
       expect(activeGame.projector({ id: 'FAKE_PLAYER_ID' }, [ game ])).toEqual(game);
+    });
+  });
+});
+
+describe('activeGameId', () => {
+  describe('when there is no active game', () => {
+    it('should return undefined', () => {
+      expect(activeGameId.projector(null)).toBe(undefined);
+    });
+  });
+
+  describe('when the active game is given', () => {
+    it('should extract the game\'s id', () => {
+      expect(activeGameId.projector({ id: 'FAKE_GAME_ID' })).toEqual('FAKE_GAME_ID');
     });
   });
 });

--- a/src/app/games/games.selectors.ts
+++ b/src/app/games/games.selectors.ts
@@ -23,6 +23,11 @@ export const activeGame = createSelector(
   (player, games) => player && games?.find(g => g.slots.find(s => s.player === player.id))
 );
 
+export const activeGameId = createSelector(
+  activeGame,
+  activeGame => activeGame?.id
+);
+
 export const isPlayingGame = createSelector(
   activeGame,
   game => !!game,

--- a/src/app/queue/active-game-snackbar/active-game-snackbar.component.html
+++ b/src/app/queue/active-game-snackbar/active-game-snackbar.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="game"
+<div *ngIf="gameId"
   class="mdc-snackbar active-game-snackbar"
   #container>
   <div class="mdc-snackbar__surface" role="status" aria-relevant="additions">
@@ -6,7 +6,7 @@
       You are involved in a currently running game.
     </div>
     <div class="mdc-snackbar__actions" aria-atomic="true">
-      <a [routerLink]="['/game', game.id]"
+      <a [routerLink]="['/game', gameId]"
         class="mdc-button mdc-snackbar__action">
         <div class="mdc-button__ripple"></div>
         <span class="mdc-button__label">Go back to the game</span>

--- a/src/app/queue/active-game-snackbar/active-game-snackbar.component.spec.ts
+++ b/src/app/queue/active-game-snackbar/active-game-snackbar.component.spec.ts
@@ -34,9 +34,7 @@ describe('ActiveGameSnackbarComponent', () => {
 
   describe('with game', () => {
     beforeEach(() => {
-      component.game = {
-        id: 'FAKE_GAME_ID',
-      } as any;
+      component.gameId = 'FAKE_GAME_ID';
       fixture.detectChanges();
     });
 

--- a/src/app/queue/active-game-snackbar/active-game-snackbar.component.ts
+++ b/src/app/queue/active-game-snackbar/active-game-snackbar.component.ts
@@ -11,7 +11,7 @@ import { MDCSnackbar } from '@material/snackbar';
 export class ActiveGameSnackbarComponent implements AfterViewChecked, OnDestroy {
 
   @Input()
-  game: Game;
+  gameId: string;
 
   @ViewChild('container')
   container: ElementRef;
@@ -19,7 +19,7 @@ export class ActiveGameSnackbarComponent implements AfterViewChecked, OnDestroy 
   private snackbar?: MDCSnackbar;
 
   ngAfterViewChecked() {
-    if (this.game && this.container) {
+    if (this.gameId && this.container) {
       this.createSnackbar();
     }
   }

--- a/src/app/queue/active-game-snackbar/active-game-snackbar.component.ts
+++ b/src/app/queue/active-game-snackbar/active-game-snackbar.component.ts
@@ -1,5 +1,4 @@
 import { Component, ChangeDetectionStrategy, Input, ViewChild, ElementRef, OnDestroy, AfterViewChecked } from '@angular/core';
-import { Game } from '@app/games/models/game';
 import { MDCSnackbar } from '@material/snackbar';
 
 @Component({

--- a/src/app/queue/queue-alerts/queue-alerts.component.html
+++ b/src/app/queue/queue-alerts/queue-alerts.component.html
@@ -1,8 +1,8 @@
 <app-ban-banner *ngFor="let ban of bans | async"
   [ban]="ban"></app-ban-banner>
 
-<app-active-game-snackbar *ngIf="activeGame | async as _activeGame"
-  [game]="_activeGame"></app-active-game-snackbar>
+<app-active-game-snackbar *ngIf="activeGameId | async as _activeGameId"
+  [gameId]="_activeGameId"></app-active-game-snackbar>
 
 <app-substitute-request-banner *ngFor="let sr of substituteRequests | async"
   [substituteRequest]="sr"></app-substitute-request-banner>

--- a/src/app/queue/queue-alerts/queue-alerts.component.spec.ts
+++ b/src/app/queue/queue-alerts/queue-alerts.component.spec.ts
@@ -6,7 +6,7 @@ import { Store, MemoizedSelector } from '@ngrx/store';
 import { By } from '@angular/platform-browser';
 import { AppState } from '@app/app.state';
 import { Game } from '@app/games/models/game';
-import { activeGame } from '@app/games/games.selectors';
+import { activeGame, activeGameId } from '@app/games/games.selectors';
 import { PlayerBan } from '@app/players/models/player-ban';
 import { bans } from '@app/profile/profile.selectors';
 import { SubstituteRequest } from '../models/substitute-request';
@@ -20,7 +20,7 @@ describe('QueueAlertsComponent', () => {
   let component: QueueAlertsComponent;
   let fixture: ComponentFixture<QueueAlertsComponent>;
   let store: MockStore<any>;
-  let activeGameSelector: MemoizedSelector<AppState, Game>;
+  let activeGameIdSelector: MemoizedSelector<AppState, string>;
   let bansSelector: MemoizedSelector<AppState, PlayerBan[]>;
   let substituteRequestsSelector: MemoizedSelector<AppState, SubstituteRequest[]>;
 
@@ -44,7 +44,7 @@ describe('QueueAlertsComponent', () => {
 
   beforeEach(() => {
     store = TestBed.inject(MockStore);
-    activeGameSelector = store.overrideSelector(activeGame, null);
+    activeGameIdSelector = store.overrideSelector(activeGameId, null);
     bansSelector = store.overrideSelector(bans, []);
     substituteRequestsSelector = store.overrideSelector(substituteRequests, []);
 
@@ -81,16 +81,10 @@ describe('QueueAlertsComponent', () => {
   });
 
   describe('with active game', () => {
-    const mockGame: Game = {
-      id: 'FAKE_GAME_ID',
-      // eslint-disable-next-line id-blacklist
-      number: 234,
-      launchedAt: new Date(),
-      map: 'cp_badlands',
-    } as any;
+    const gameId = 'FAKE_GAME_ID';
 
     beforeEach(() => {
-      activeGameSelector.setResult(mockGame);
+      activeGameIdSelector.setResult(gameId);
       store.refreshState();
       fixture.detectChanges();
     });
@@ -99,7 +93,7 @@ describe('QueueAlertsComponent', () => {
       const activeGameSnackbar = fixture.debugElement.query(By.css('app-active-game-snackbar'))
         .componentInstance as ActiveGameSnackbarComponent;
       expect(activeGameSnackbar).toBeTruthy();
-      expect(activeGameSnackbar.game).toEqual(mockGame);
+      expect(activeGameSnackbar.gameId).toEqual(gameId);
     });
   });
 
@@ -117,7 +111,7 @@ describe('QueueAlertsComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should render the subsitute alert banner', () => {
+    it('should render the substitute alert banner', () => {
       const substituteRequestBanner = fixture.debugElement.query(By.css('app-substitute-request-banner'))
         .componentInstance as SubstituteRequestBannerComponent;
       expect(substituteRequestBanner).toBeTruthy();

--- a/src/app/queue/queue-alerts/queue-alerts.component.ts
+++ b/src/app/queue/queue-alerts/queue-alerts.component.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { activeGame } from '@app/games/games.selectors';
+import { activeGameId } from '@app/games/games.selectors';
 import { Store } from '@ngrx/store';
 import { bans } from '@app/profile/profile.selectors';
 import { substituteRequests } from '../queue.selectors';
@@ -12,7 +12,7 @@ import { substituteRequests } from '../queue.selectors';
 })
 export class QueueAlertsComponent {
 
-  activeGame = this.store.select(activeGame);
+  activeGameId = this.store.select(activeGameId);
   bans = this.store.select(bans);
   substituteRequests = this.store.select(substituteRequests);
 


### PR DESCRIPTION
Fix the issue with jumping snackbar each time the active game was updated.